### PR TITLE
unlock composer installation for Contao 3 & 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Tags and tagcloud for News4ward",
   "keywords": ["news", "blog", "tags"],
   "type": "contao-module",
-  "license": "LGPL-3.0+",
+  "license": "LGPL-3.0-or-later",
   "authors": [
     {
       "name": "Christoph Wiechert",
@@ -21,15 +21,13 @@
   },
   "require": {
     "php": ">=5.3",
-    "contao/core": ">=3.1,<4",
+    "contao/core-bundle": "^3.2.1 || ^4.4",
+    "contao-community-alliance/composer-plugin": "^2.4 || ^3.0",
     "psi/news4ward": "~2",
     "psi/tags-widget": "~2"
   },
   "replace": {
     "contao-legacy/news4ward_tags": "*"
-  },
-  "conflict": {
-    "contao/core": "3.0.*"
   },
   "extra": {
     "contao": {


### PR DESCRIPTION
This PR provides changes to the composer.json, so that this extension can be installed in Contao 3 and 4.
These changes are not tested.